### PR TITLE
Enable to resize Events too

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,23 @@ var bpmnJS = new BpmnModeler({
   additionalModules: [
     resizeTask
   ],
-  taskResizingEnabled: true
+  taskResizingEnabled: true,
+});
+```
+
+In order to allow resize events to, set the `eventResizingEnabled` config:
+
+```javascript
+import BpmnModeler from 'bpmn-js/lib/Modeler';
+
+import resizeTask from 'bpmn-js-task-resize/lib';
+
+var bpmnJS = new BpmnModeler({
+  additionalModules: [
+    resizeTask
+  ],
+  taskResizingEnabled: true,
+  eventResizingEnabled: true
 });
 ```
 

--- a/lib/ResizeEvent.js
+++ b/lib/ResizeEvent.js
@@ -1,0 +1,26 @@
+import RuleProvider from 'diagram-js/lib/features/rules/RuleProvider';
+import inherits from 'inherits';
+
+
+export default function ResizeEvent(eventBus, eventResizingEnabled) {
+  RuleProvider.call(this, eventBus);
+  this.eventResizingEnabled = eventResizingEnabled || false;
+}
+
+inherits(ResizeEvent, RuleProvider);
+
+ResizeEvent.$inject = ['eventBus', 'config.eventResizingEnabled'];
+
+ResizeEvent.prototype.init = function () {
+  var me = this;
+
+  me.addRule('shape.resize', 1500, function (data) {
+    if (me.eventResizingEnabled && data.shape.businessObject &&
+      data.shape.businessObject.$instanceOf('bpmn:Event')) {
+      if (data.newBounds) {
+        data.newBounds.width = Math.max(36, data.newBounds.width);
+        data.newBounds.height = Math.max(36, data.newBounds.height);
+      } return true;
+    }
+  });
+};

--- a/lib/ResizeTask.js
+++ b/lib/ResizeTask.js
@@ -15,20 +15,13 @@ ResizeTask.prototype.init = function() {
   var me=this;
 
   me.addRule('shape.resize', 1500, function(data) {
-    if (me.taskResizingEnabled && data.shape.businessObject &&
-        (data.shape.businessObject.$instanceOf('bpmn:Task') ||
+    if (me.taskResizingEnabled && data.shape.businessObject && 
+        (data.shape.businessObject.$instanceOf('bpmn:Task') || 
          data.shape.businessObject.$instanceOf('bpmn:CallActivity') ||
          data.shape.businessObject.$instanceOf('bpmn:SubProcess'))) {
       if (data.newBounds) {
         data.newBounds.width=Math.max(100,data.newBounds.width);
         data.newBounds.height=Math.max(80,data.newBounds.height);
-      }
-      return true;
-    } else if (me.taskResizingEnabled && data.shape.businessObject &&
-         data.shape.businessObject.$instanceOf('bpmn:Event')) {
-      if (data.newBounds) {
-        data.newBounds.width=Math.max(36,data.newBounds.width);
-        data.newBounds.height=Math.max(36,data.newBounds.height);
       }
       return true;
     }

--- a/lib/ResizeTask.js
+++ b/lib/ResizeTask.js
@@ -15,13 +15,20 @@ ResizeTask.prototype.init = function() {
   var me=this;
 
   me.addRule('shape.resize', 1500, function(data) {
-    if (me.taskResizingEnabled && data.shape.businessObject && 
-        (data.shape.businessObject.$instanceOf('bpmn:Task') || 
+    if (me.taskResizingEnabled && data.shape.businessObject &&
+        (data.shape.businessObject.$instanceOf('bpmn:Task') ||
          data.shape.businessObject.$instanceOf('bpmn:CallActivity') ||
          data.shape.businessObject.$instanceOf('bpmn:SubProcess'))) {
       if (data.newBounds) {
         data.newBounds.width=Math.max(100,data.newBounds.width);
         data.newBounds.height=Math.max(80,data.newBounds.height);
+      }
+      return true;
+    } else if (me.taskResizingEnabled && data.shape.businessObject &&
+         data.shape.businessObject.$instanceOf('bpmn:Event')) {
+      if (data.newBounds) {
+        data.newBounds.width=Math.max(36,data.newBounds.width);
+        data.newBounds.height=Math.max(36,data.newBounds.height);
       }
       return true;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 import ResizeTask from './ResizeTask';
+import ResizeEvent from './ResizeEvent';
 
 export default {
-  __init__: [ 'resizeTask' ],
-  resizeTask: [ 'type', ResizeTask ]
+  __init__: [ 'resizeTask', 'resizeEvent' ],
+  resizeTask: [ 'type', ResizeTask ],
+  resizeEvent: [ 'type', ResizeEvent ]
 };


### PR DESCRIPTION
I would like to resize BPMN Events and I found this plugin, but it only enable to resize tasks, activities and subprocesses.

Is there a reason so it is not possible currently?

I made this change to the code to enable to resize the Events too. I opened this PR if would like to add this feature to the original plugin.

Thanks for the plugin!
